### PR TITLE
Resolve `ember-cli-rails` configuration errors

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,6 +17,9 @@ Dir.chdir APP_ROOT do
   #   system "cp config/database.yml.sample config/database.yml"
   # end
 
+  puts "\n== Installing Ember dependencies =="
+  system "bin/rake ember:install"
+
   puts "\n== Preparing database =="
   system "bin/rake db:setup"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   resources :users
   resources :posts
-  root 'application#index'
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/frontend/app/models/post.js
+++ b/frontend/app/models/post.js
@@ -1,6 +1,6 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend(
+export default DS.Model.extend({
   user_id: DS.belongsTo('user'),
 
   title: DS.attr('string'),

--- a/frontend/app/templates/index.hbs
+++ b/frontend/app/templates/index.hbs
@@ -1,6 +1,6 @@
 <h1>Hello world</h1>
 <ul>
-  {{#each posts |post|}}
+  {{#each posts as |post|}}
       <li class="post">{{post.title}}</li>
   {{/each}}
 </ul>


### PR DESCRIPTION
Closes [thoughtbot/ember-cli-rails#509].

This repository had improper configuration preventing EmberCliRails from
serving the embedded Ember application.

1.  The `bin/setup` script wasn't installing the embedded Ember
    application's dependencies. To resolve this issue, a call to `rake
    ember:install` was added to the script.
1.  The call to `mount_ember_app` in `config/routes.rb` was declared
    _below_ the `root` call, making the Ember route unreachable. To
    resolve this issue, the call to `root` was removed. As an alternative,
    the `root` declaration could be moved below the `mount_ember_app`
    declaration. In this case, that didn't apply because of the `to:
    "/"` argument passed to `mount_ember_app`.
1.  There were minor syntax issues in the embedded Ember application
    which were preventing the embedded `ember serve` process from building
    and serving the application. These have been resolved.

The original error in [thoughtbot/ember-cli-rails#509]:

```
undefined local variable or method `ember_app`
```

is likely due to an out of date gem version.

This project specifies `ember-cli-rails@0.8.3`, so [the `ember_app`
helper method is no longer invoked from the
`app/views/ember_cli/ember/show.html.erb` template][removal], since it
was removed in the `0.8.0` release.

The issue could be resolved by refreshing the project's gems and
ensuring that at least `ember-cli-rails@0.8.0` is specified.

[thoughtbot/ember-cli-rails#509]: https://github.com/thoughtbot/ember-cli-rails/issues/509
[removal]: https://github.com/thoughtbot/ember-cli-rails/commit/876720b0b2b00fb2e1bb64234e42b108f69bc315#diff-83c37ba8df2706343b883fc4b6825b2d